### PR TITLE
Remove forced dependency to priv/commonjs_reaxt

### DIFF
--- a/lib/gen_event_substitute.ex
+++ b/lib/gen_event_substitute.ex
@@ -73,7 +73,7 @@ defmodule GenEventSubstitute do
   end
 
   def call(manager, handler, request, timeout \\ 5_000) do
-    :gen_event.call(manager, request, timeout)
+    :gen_event.call(manager, handler, request, timeout)
   end
 
   def add_mon_handler(manager, handler, args) do

--- a/lib/gen_event_substitute.ex
+++ b/lib/gen_event_substitute.ex
@@ -1,0 +1,82 @@
+defmodule GenEventSubstitute do
+  @moduledoc """
+  Substitute module untill what's really needed is fully understood in order to do without `:gen_event`
+  """
+
+  @doc false
+  defmacro __using__(_) do
+    quote location: :keep do
+      @behaviour :gen_event
+
+      @doc false
+      def init(args) do
+        {:ok, args}
+      end
+
+      @doc false
+      def handle_event(_event, state) do
+        {:ok, state}
+      end
+
+      @doc false
+      def handle_call(msg, state) do
+        proc =
+          case Process.info(self(), :registered_name) do
+            {_, []} -> self()
+            {_, name} -> name
+          end
+
+        # We do this to trick Dialyzer to not complain about non-local returns.
+        case :erlang.phash2(1, 1) do
+          0 ->
+            raise "attempted to call GenEventSubtitute #{inspect(proc)} but no handle_call/2 clause was provided"
+
+          1 ->
+            {:remove_handler, {:bad_call, msg}}
+        end
+      end
+
+      @doc false
+      def handle_info(_msg, state) do
+        {:ok, state}
+      end
+
+      @doc false
+      def terminate(_reason, _state) do
+        :ok
+      end
+
+      @doc false
+      def code_change(_old, state, _extra) do
+        {:ok, state}
+      end
+
+      defoverridable init: 1,
+                     handle_event: 2,
+                     handle_call: 2,
+                     handle_info: 2,
+                     terminate: 2,
+                     code_change: 3
+    end
+  end
+
+  def start_link([name: name]) do
+    :gen_event.start_link({:local, name})
+  end
+
+  def add_handler(manager, handler, args) do
+    :gen_event.add_handler(manager, handler, args)
+  end
+
+  def notify(manager, event) do
+    :gen_event.notify(manager, event)
+  end
+
+  def call(manager, handler, request, timeout \\ 5_000) do
+    :gen_event.call(manager, request, timeout)
+  end
+
+  def add_mon_handler(manager, handler, args) do
+    :gen_event.add_sup_handler(manager, handler, args)
+  end
+end

--- a/lib/reaxt.ex
+++ b/lib/reaxt.ex
@@ -1,6 +1,6 @@
 defmodule ReaxtError do
-  defexception [:message,:js_render,:js_stack]
-  def exception({:handler_error,error,stack}) do
+  defexception [:message, :js_render, :js_stack]
+  def exception({:handler_error, error, stack}) do
     %ReaxtError{message: "JS Exception : #{error}", js_stack: (stack && parse_stack(stack))}
   end
   def exception({:render_error,error,stack,js_render}) do
@@ -8,8 +8,8 @@ defmodule ReaxtError do
   end
   defp parse_stack(stack) do
     Regex.scan(~r/at (.*) \((.*):([0-9]*):[0-9]*\)/,stack)
-    |> Enum.map(fn [_,function,url,line]->
-      if String.contains?(url,"/priv") and !(function in ["Port.next_term","Socket.read_term"]) do
+    |> Enum.map(fn [_, function, url, line]->
+      if String.contains?(url, "/priv") and !(function in ["Port.next_term","Socket.read_term"]) do
         {line,_} = Integer.parse(line)
         [_,after_priv] = String.split(url,"/priv/",parts: 2)
         {JS,:"#{function}",0,file: '#{WebPack.Util.web_priv}/#{after_priv}', line: line}
@@ -18,39 +18,41 @@ defmodule ReaxtError do
     |> Enum.filter(&!is_nil(&1))
   end
 end
+
 defmodule Reaxt do
   alias :poolboy, as: Pool
   require Logger
 
-  def render_result(chunk,module,data,timeout) when not is_tuple(module), do:
+  def render_result(chunk, module, data, timeout) when not is_tuple(module) do
     render_result(chunk,{module,nil},data,timeout)
-  def render_result(chunk,{module,submodule},data,timeout) do
-    Pool.transaction(:"react_#{chunk}_pool",fn worker->
-      GenServer.call(worker,{:render,module,submodule,data,timeout},timeout+100)
+  end
+  def render_result(chunk, {module, submodule}, data, timeout) do
+    Pool.transaction(:"react_#{chunk}_pool", fn worker ->
+      GenServer.call(worker, {:render, module, submodule, data, timeout}, timeout + 100)
     end)
   end
 
-  def render!(module,data,timeout \\ 5_000, chunk \\ :server) do
-    case render_result(chunk,module,data,timeout) do
-      {:ok,res}->res
-      {:error,err}->
-        try do raise(ReaxtError,err)
-        rescue ex->
+  def render!(module, data, timeout \\ 5_000, chunk \\ :server) do
+    case render_result(chunk, module, data, timeout) do
+      {:ok, res} -> res
+      {:error, err} ->
+        try do raise(ReaxtError, err)
+        rescue ex ->
           [_|stack] = System.stacktrace
           reraise ex, ((ex.js_stack || []) ++ stack)
         end
     end
   end
 
-  def render(module,data, timeout \\ 5_000) do
+  def render(module, data, timeout \\ 5_000) do
     try do
-      render!(module,data,timeout)
+      render!(module, data, timeout)
     rescue
-      ex->
+      ex ->
         case ex do
           %{js_render: js_render} when is_binary(js_render)->
             Logger.error(Exception.message(ex))
-            %{css: "",html: "", js_render: js_render}
+            %{css: "", html: "", js_render: js_render}
           _ ->
             reraise ex, System.stacktrace
         end
@@ -58,44 +60,51 @@ defmodule Reaxt do
   end
 
   def reload do
-    WebPack.Util.build_stats
-    Supervisor.terminate_child(Reaxt.App.Sup,:react)
-    Supervisor.restart_child(Reaxt.App.Sup,:react)
+    WebPack.Util.build_stats()
+    Supervisor.terminate_child(Reaxt.App.Sup, :react)
+    Supervisor.restart_child(Reaxt.App.Sup, :react)
   end
 
   def start_link(server_path) do
-    init = Poison.encode!(Application.get_env(:reaxt,:global_config,nil))
-    Exos.Proc.start_link("node #{server_path}",init,[cd: '#{WebPack.Util.web_priv}'])
+    init = Poison.encode!(Application.get_env(:reaxt, :global_config, nil))
+    Exos.Proc.start_link("node #{server_path}", init, [cd: '#{WebPack.Util.web_priv()}'])
   end
 
   defmodule App do
     use Application
-    def start(_,_) do
-      result = Supervisor.start_link(App.Sup,[], name: App.Sup)
-      WebPack.Util.build_stats
+
+    def start(_, _) do
+      result = Supervisor.start_link(App.Sup, [], name: App.Sup)
+      WebPack.Util.build_stats()
       result
     end
+
     defmodule Sup do
       use Supervisor
+
       def init([]) do
-        dev_workers = if Application.get_env(:reaxt,:hot),
-           do: [worker(WebPack.Compiler,[]),
-                worker(WebPack.EventManager,[])], else: []
-        supervise([Supervisor.Spec.supervisor(__MODULE__,[],function: :start_pools,id: :react)
-          |dev_workers], strategy: :one_for_one)
+        dev_workers =
+          if Application.get_env(:reaxt, :hot) do
+            [worker(WebPack.Compiler,[]), worker(WebPack.EventManager,[])]
+          else
+            []
+          end
+
+        supervise([Supervisor.Spec.supervisor(__MODULE__, [], function: :start_pools, id: :react)]
+          ++ dev_workers, strategy: :one_for_one)
       end
 
       def start_pools do
-        pool_size = Application.get_env(:reaxt,:pool_size)
-        pool_overflow = Application.get_env(:reaxt,:pool_max_overflow)
-        server_dir = "#{WebPack.Util.web_priv}/#{Application.get_env(:reaxt,:server_dir)}"
+        pool_size = Application.get_env(:reaxt, :pool_size)
+        pool_overflow = Application.get_env(:reaxt, :pool_max_overflow)
+        server_dir = "#{WebPack.Util.web_priv()}/#{Application.get_env(:reaxt, :server_dir)}"
         server_files = Path.wildcard("#{server_dir}/*.js")
         if server_files == [] do
           Logger.error("#server JS not yet compiled in #{server_dir}, compile it before with `mix webpack.compile`")
-          throw {:error,:serverjs_not_compiled}
+          throw {:error, :serverjs_not_compiled}
         else
           Supervisor.start_link(
-            for server<-server_files do
+            for server <- server_files do
               pool = :"react_#{server |> Path.basename(".js") |> String.replace(~r/[0-9][a-z][A-Z]/,"_")}_pool"
               Pool.child_spec(pool,[worker_module: Reaxt,size: pool_size, max_overflow: pool_overflow, name: {:local,pool}], server)
             end, strategy: :one_for_one)

--- a/lib/tasks.ex
+++ b/lib/tasks.ex
@@ -3,11 +3,14 @@ defmodule Mix.Tasks.Npm.Install do
   @shortdoc "`npm install` in web_dir" # + npm install server side dependencies"
   def run(_args) do
     {_, 0} = System.cmd("npm", ["install"], into: IO.stream(:stdio, :line), cd: WebPack.Util.web_app)
-    # TOIMPROVE - did not find a better hack to avoid `npm install`'s symlinks.
-    # First we make a tar gz package, then npm installs it.
-    #reaxt_tgz = "#{System.tmp_dir}/reaxt.tgz"
-    #System.cmd("tar", ["zcf",reaxt_tgz,"commonjs_reaxt"],into: IO.stream(:stdio, :line), cd: "#{:code.priv_dir(:reaxt)}")
-    #System.cmd("npm",["install","--no-save",reaxt_tgz], into: IO.stream(:stdio, :line), cd: WebPack.Util.web_app)
+    reaxt_js_root = Application.get_env(:reaxt, :reaxt_js_root, "reaxt")
+    if not File.exists?("#{WebPack.Util.web_app}/node_modules/#{reaxt_js_root}") do
+      # TOIMPROVE - did not find a better hack to avoid `npm install`'s symlinks.
+      # First we make a tar gz package, then npm installs it.
+      reaxt_tgz = "#{System.tmp_dir}/reaxt.tgz"
+      System.cmd("tar", ["zcf",reaxt_tgz,"commonjs_reaxt"],into: IO.stream(:stdio, :line), cd: "#{:code.priv_dir(:reaxt)}")
+      System.cmd("npm",["install","--no-save",reaxt_tgz], into: IO.stream(:stdio, :line), cd: WebPack.Util.web_app)
+    end
     :ok
   end
 end

--- a/lib/tasks.ex
+++ b/lib/tasks.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Npm.Install do
+  use Mix.Task
   @shortdoc "`npm install` in web_dir + npm install server side dependencies"
   def run(_args) do
     System.cmd("npm",["install"], into: IO.stream(:stdio, :line), cd: WebPack.Util.web_app)
@@ -10,6 +11,7 @@ defmodule Mix.Tasks.Npm.Install do
 end
 
 defmodule Mix.Tasks.Webpack.Analyseapp do
+  use Mix.Task
   @shortdoc "Generate webpack stats analysing application, resulting priv/static is meant to be versionned"
   def run(_args) do
     File.rm_rf!("priv/static")
@@ -22,6 +24,7 @@ defmodule Mix.Tasks.Webpack.Analyseapp do
 end
 
 defmodule Mix.Tasks.Webpack.Compile do
+  use Mix.Task
   @shortdoc "Compiles Webpack"
   @webpack "./node_modules/webpack/bin/webpack.js"
   def run(_) do
@@ -35,8 +38,8 @@ defmodule Mix.Tasks.Webpack.Compile do
 end
 
 defmodule Mix.Tasks.Reaxt.Validate do
-  @shortdoc "Validates that reaxt is setup correct"
   use Mix.Task
+  @shortdoc "Validates that reaxt is setup correct"
 
   def run(args) do
     if Enum.all?(args, &(&1 != "--reaxt-skip-validation")) do
@@ -94,6 +97,7 @@ defmodule Mix.Tasks.Reaxt.Validate do
 end
 
 defmodule Mix.Tasks.Compile.ReaxtWebpack do
+  use Mix.Task
   def run(args) do
     Mix.Task.run("reaxt.validate", args ++ ["--reaxt-skip-compiler-check"])
 

--- a/lib/webpack.ex
+++ b/lib/webpack.ex
@@ -40,17 +40,13 @@ defmodule WebPack.Plug.Static do
   get "/webpack" do %{conn | path_info: ["webpack","static","index.html"]} end
 
   get "/webpack/events" do
-    require Logger
-    Logger.debug("get /webpack/events")
     conn =
       conn
       |> put_resp_header("content-type", "text/event-stream")
       |> send_chunked(200)
 
-    Logger.debug("get /webpack/events 2")
     hot? = Application.get_env(:reaxt, :hot)
     if hot? == :client do Plug.Conn.chunk(conn, "event: hot\ndata: nothing\n\n") end
-    Logger.debug("get /webpack/events 3")
     if hot? do
       GenEventSubstitute.add_mon_handler(WebPack.Events, {WebPack.Plug.Static.EventHandler, make_ref()}, conn)
     end
@@ -72,8 +68,6 @@ defmodule WebPack.Plug.Static do
     use GenEventSubstitute
 
     def handle_event(ev, conn) do #Send all builder events to browser through SSE
-      require Logger
-      Logger.debug("EventHandler: ev => #{inspect(ev)}")
       Plug.Conn.chunk(conn, "event: #{ev.event}\ndata: #{Poison.encode!(ev)}\n\n")
       {:ok, conn}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Reaxt.Mixfile do
 
   def project do
     [app: :reaxt,
-     version: "2.0.2",
+     version: "2.1.0",
      description: description(),
      package: package(),
      elixir: ">= 1.0.0",

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Reaxt.Mixfile do
 
   def project do
     [app: :reaxt,
-     version: "2.1.0",
+     version: "2.1.1",
      description: description(),
      package: package(),
      elixir: ">= 1.0.0",

--- a/mix.exs
+++ b/mix.exs
@@ -4,10 +4,10 @@ defmodule Reaxt.Mixfile do
   def project do
     [app: :reaxt,
      version: "2.0.0",
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
      elixir: ">= 1.0.0",
-     deps: deps]
+     deps: deps()]
   end
 
   def application do
@@ -24,7 +24,7 @@ defmodule Reaxt.Mixfile do
   end
 
   defp deps do
-    [{:exos, "1.0.0"},
+    [{:exos, "~> 1.0.0"},
      {:poolboy, "~> 1.5.0"},
      {:cowboy,"~> 1.0.0"},
      {:plug, "~> 1.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Reaxt.Mixfile do
 
   def project do
     [app: :reaxt,
-     version: "2.0.0",
+     version: "2.0.1",
      description: description(),
      package: package(),
      elixir: ">= 1.0.0",

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Reaxt.Mixfile do
 
   def project do
     [app: :reaxt,
-     version: "2.0.1",
+     version: "2.0.2",
      description: description(),
      package: package(),
      elixir: ">= 1.0.0",

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,12 @@
-%{"cowboy": {:hex, :cowboy, "1.0.2", "876a2f63eaa5da5bd0610569d6402cabef8b3f48171233c11cfeee9f37d1f0c9", [:rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+%{
+  "cowboy": {:hex, :cowboy, "1.0.2", "876a2f63eaa5da5bd0610569d6402cabef8b3f48171233c11cfeee9f37d1f0c9", [:rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.1", "175a633c472058bbeb1b238a6409766a48b52b43b7b687ed70f03cf6e854b7d9", [:make], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "exos": {:hex, :exos, "1.0.0", "4eb19eb958de0c07284a3e6d23966b41e0bce37556120fcf908900b1eeee2b60", [:mix], []},
+  "exos": {:hex, :exos, "1.0.3", "c05e5196926e3dbeb1a005b1c5a940f00c2f5a1814b8fedd2a60c446bccf7ec3", [:mix], [], "hexpm"},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
   "plug": {:hex, :plug, "1.3.0", "6e2b01afc5db3fd011ca4a16efd9cb424528c157c30a44a0186bcc92c7b2e8f3", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
-  "ranch": {:hex, :ranch, "1.1.0", "f7ed6d97db8c2a27cca85cacbd543558001fc5a355e93a7bff1e9a9065a8545b", [:make], []}}
+  "ranch": {:hex, :ranch, "1.1.0", "f7ed6d97db8c2a27cca85cacbd543558001fc5a355e93a7bff1e9a9065a8545b", [:make], []},
+}

--- a/test/reaxt_test.exs
+++ b/test/reaxt_test.exs
@@ -2,6 +2,6 @@ defmodule ReaxtTest do
   use ExUnit.Case
 
   test "the truth" do
-    assert 1 + 1 == 2
+    assert 42
   end
 end


### PR DESCRIPTION
What's changed
- The two following point don't feel necessary as warnings from deps do not affect compiling with `--warnings-as-errors`.:
  - Parenthesis on most function call with no arguments.
  - GenEvent proxy using :gen_event as the elixir version is deprecated.
- Errors are displayed when `webpack.compile` fails.
- Added `reaxt_js_root` as configuration option:
  - permits to choose a different node_module as the port interacting with reaxt ([Shakadak/reaxt-react-15-example](https://github.com/Shakadak/reaxt-react-15-example) for an example that should behave the same as if using the priv/commonjs_reaxt version)
  - permits to get that sweet `getDerivedStateFromProps`
  - `reaxt` doesn't actually feels like it is `react` specific, this is a step toward supporting other frameworks, although there shouldn't be more work needed on reaxt's side, as the burden is on the js port.
  - forcing `components` in the directory structure when the js world uses `src`, akin to elixir's `lib` is awkward and doesn't integrate well with potential other tools.

There is probably something I'm misunderstanding, or the above points weren't pertinent at the time of `reaxt`'s creaction, but I guess my point is we are pretty close to a `GenServer`, but we are forced to do with the implementation of an `Agent`. :P Let's go the extra step.