### PR TITLE
Add parallel webpack support

### DIFF
--- a/lib/tasks.ex
+++ b/lib/tasks.ex
@@ -29,7 +29,9 @@ defmodule Mix.Tasks.Webpack.Compile do
   use Mix.Task
 
   @shortdoc "Compiles Webpack"
+  @webpack_parallel"./node_modules/parallel-webpack/bin/run.js"
   @webpack "./node_modules/webpack/bin/webpack.js"
+
   def run(_) do
     case compile() do
       {json, 0} ->
@@ -47,7 +49,8 @@ defmodule Mix.Tasks.Webpack.Compile do
 
   def compile() do
     config = "./"<>WebPack.Util.webpack_config
-    System.cmd("node",[@webpack,"--config",config,"--json"], into: "", cd: WebPack.Util.web_app)
+    webpack = if WebPack.Util.parallel_build, do: @webpack_parallel, else: @webpack
+    System.cmd("node",[webpack,"--config",config,"--json"], into: "", cd: WebPack.Util.web_app)
   end
 end
 

--- a/lib/webpack.ex
+++ b/lib/webpack.ex
@@ -88,7 +88,7 @@ defmodule WebPack.EventManager do
       {:ok,_} = Supervisor.restart_child(Reaxt.App.Sup,:react)
     end
     if ev[:error] do
-      Logger.error("[rext-webpack] error compiling server_side JS #{ev[:error]}")
+      Logger.error("[reaxt-webpack] error compiling server_side JS #{ev[:error]}")
       if ev[:error] != "soft fail", do:
         System.halt(1)
     end
@@ -142,10 +142,17 @@ defmodule WebPack.Util do
     Application.get_env :reaxt, :web_app, "web"
   end
 
+  def parallel_build do
+    ## We can't have parallel AND hot reload together
+    Application.get_env(:reaxt, :hot, false) == false && Application.get_env(:reaxt, :parallel, false)
+  end
+
   def build_stats do
     if File.exists?("#{web_priv()}/webpack.stats.json") do
       all_stats = Poison.decode!(File.read!("#{web_priv()}/webpack.stats.json"))
-      stats = all_stats["children"] |> Enum.with_index |> Enum.into(%{},fn {stats,idx}->
+      #The format of the stats from parallel-webpack is different than the raw one from webpack
+      stats_array = if WebPack.Util.parallel_build, do: all_stats, else: all_stats["children"]
+      stats = stats_array |> Enum.with_index |> Enum.into(%{},fn {stats,idx}->
          {idx,%{assetsByChunkName: stats["assetsByChunkName"],
                 errors: stats["errors"],
                 warnings: stats["warnings"]}}

--- a/priv/commonjs_reaxt/package.json
+++ b/priv/commonjs_reaxt/package.json
@@ -7,6 +7,7 @@
     "node_erlastic": "~0.0.1",
     "style-loader": "0.8.2",
     "loader-utils": "^0.2.5",
-    "react-dom": "^15.4.1"
+    "react-dom": "^15.4.1",
+    "parallel-webpack": "^2.4.0"
   }
 }


### PR DESCRIPTION
Add the use of [parallel-webpack](https://github.com/trivago/parallel-webpack) when hot reload is deactivated, allowing faster build in prod environment.